### PR TITLE
Convert jsonapi payload to pojo

### DIFF
--- a/lib/transformalizer.js
+++ b/lib/transformalizer.js
@@ -1,9 +1,12 @@
+import 'babel-polyfill'
+
 import {
   isFunction,
   isObject,
   isString,
   TransformError,
   validateSchema,
+  validateJsonApiDocument,
 } from './utils'
 
 /**
@@ -423,6 +426,270 @@ export default function createTransformalizer(baseOptions = {}) {
     }
   }
 
+  /**
+   * Untransform a valid JSON API document into raw data
+   * @param  {Object} args
+   * @param  {Object} args.document - a json-api formatted document
+   * @param  {Object} [options={}] - function level options
+   * @return {Object[]} an array of data objects
+   */
+  function untransform({ document, options: opts }) {
+    // validate json api document
+    validateJsonApiDocument(document)
+
+    const options = Object.assign({}, baseOptions, opts)
+    const data = {}
+    const resourceDataMap = []
+
+    if (Array.isArray(document.data)) {
+      document.data.forEach(resource => untransformResource({ resource, data, resourceDataMap, document, options }))
+    } else {
+      untransformResource({ resource: document.data, data, resourceDataMap, document, options })
+    }
+
+    const primaryDataObjects = resourceDataMap.map(mapping => mapping.object)
+
+    // untransform included resources if desired
+    if (options.untransformIncluded && document.included) {
+      document.included.forEach(resource => untransformResource({ resource, data, resourceDataMap, document, options }))
+    }
+
+    // nest included resources if desired
+    if (options.nestIncluded) {
+      resourceDataMap.forEach(resourceDataMapping => nestRelatedResources({ resourceDataMapping, data, options }))
+
+      // remove circular dependencies if desired
+      if (options.removeCircularDependencies) {
+        const processed = new WeakSet()
+        const visited = new WeakSet()
+
+        removeCircularDependencies({ object: { root: primaryDataObjects }, processed, visited })
+      }
+    }
+
+    return data
+  }
+
+  /**
+   * Untransform a single resource object into raw data
+   * @param  {Object} args
+   * @param  {Object} args.resource - the json-api resource object
+   * @param  {Object} args.data - an object where each key is the name of a data type and each value is an array of raw data objects
+   * @param  Object[] args.resourceDataMap - an array of objects that map resources to a raw data objects
+   * @param  {Object} args.document - the json-api resource document
+   * @param  {Object} args.options - function level options
+   * @param  {Array} args.resourceDataMap - an array where each entry is an object that contains the reousrce and the corresponding raw data object
+   */
+  function untransformResource({ resource, data, resourceDataMap, document, options }) {
+    // get the appropriate data schema to use
+    const dataSchema = getUntransformedDataSchema({ type: resource.type, resource, document, options })
+
+    // untransform the resource id
+    const id = getUntransformedId({ dataSchema, id: resource.id, type: resource.type, options })
+
+    // untransform the resource attributes
+    const attributes = getUntransformedAttributes({ dataSchema, id, type: resource.type, attributes: resource.attributes, resource, options })
+
+    // create a plain javascript object with the resource id and attributes
+    const obj = Object.assign({ id }, attributes)
+
+    if (resource.relationships) {
+      // for each relationship, add the relationship to the plain javascript object
+      Object.keys(resource.relationships).forEach((relationshipName) => {
+        const relationship = resource.relationships[relationshipName].data
+
+        if (Array.isArray(relationship)) {
+          obj[relationshipName] = relationship.map((relationshipResource) => {
+            const relationshipDataSchema = getUntransformedDataSchema({ type: relationshipResource.type, resource: relationshipResource, document, options })
+
+            return { id: getUntransformedId({ dataSchema: relationshipDataSchema, id: relationshipResource.id, type: relationshipResource.type, options }) }
+          })
+        } else {
+          const relationshipDataSchema = getUntransformedDataSchema({ type: relationship.type, resource: relationship, document, options })
+
+          obj[relationshipName] = { id: getUntransformedId({ dataSchema: relationshipDataSchema, id: relationship.id, type: relationship.type, options }) }
+        }
+      })
+    }
+
+    if (!data[resource.type]) {
+      data[resource.type] = []
+    }
+
+    // add the plain javascript object to the untransformed output and map it to the resource
+    data[resource.type].push(obj)
+    resourceDataMap.push({ resource, object: obj })
+  }
+
+  /**
+   * Get the data schema to use to untransform the resource object
+   * @param  {Object} args
+   * @param  {Object} args.type - the json-api resource object type
+   * @param  {Object} args.resource - the json-api resource object
+   * @param  {Object} args.document - the json-api resource document
+   * @param  {Object} args.options - function level options
+   */
+  function getUntransformedDataSchema(args) {
+    let dataSchema = getSchema({ name: args.type })
+
+    // if the base schema defines a dataSchema function, use that to retrieve the
+    // actual schema to use, otherwise return the base schema
+    if (isFunction(dataSchema.schema.data.untransformDataSchema)) {
+      const name = dataSchema.schema.data.untransformDataSchema(args)
+
+      if (name !== dataSchema.name) {
+        dataSchema = getSchema(name)
+
+        if (!dataSchema) {
+          throw new Error(`Missing Schema: ${name}`)
+        }
+      }
+    }
+
+    return dataSchema
+  }
+
+  /**
+   * Untransform a resource object's id
+   * @param  {Object} args
+   * @param  {Object} args.dataSchema - the data schema for the resource object
+   * @param  {Object} args.id - the json-api resource object id
+   * @param  {Object} args.type - the json-api resource object type
+   * @param  {Object} args.options - function level options
+   */
+  function getUntransformedId(args) {
+    const { dataSchema, ...others } = args
+    let id = others.id
+
+    if (dataSchema.schema.data.untransformId) {
+      id = dataSchema.schema.data.untransformId(others)
+    }
+
+    return id
+  }
+
+  /**
+   * Untransform a resource object's attributes
+   * @param  {Object} args
+   * @param  {Object} args.dataSchema - the data schema for the resource object
+   * @param  {Object} args.id - the json-api resource object id, determined in the data.untransformId step
+   * @param  {Object} args.type - the json-api resource object type
+   * @param  {Object} args.attributes - the json-api resource object attributes
+   * @param  {Object} args.resource - the full json-api resource object
+   * @param  {Object} args.options - function level options
+   */
+  function getUntransformedAttributes(args) {
+    const { dataSchema, ...others } = args
+    let attributes = others.attributes
+
+    if (dataSchema.schema.data.untransformAttributes) {
+      attributes = dataSchema.schema.data.untransformAttributes(others)
+    }
+
+    return attributes
+  }
+
+  /**
+   * Nest related resources as defined by the json-api relationships
+   * @param  {Object} args
+   * @param  {Object} args.resourceDataMapping - An object that maps a resource to a raw data object
+   * @param  {Object} args.data - An object where each key is the name of a data type and each value is an array of raw data objects
+   */
+  function nestRelatedResources({ resourceDataMapping, data }) {
+    const resource = resourceDataMapping.resource
+    const obj = resourceDataMapping.object
+
+    if (resource.relationships) {
+      // for each relationship, add the relationship to the plain javascript object
+      Object.keys(resource.relationships).forEach((relationshipName) => {
+        const relationship = resource.relationships[relationshipName].data
+
+        if (Array.isArray(relationship)) {
+          obj[relationshipName] = relationship.map((relationshipResource, index) => {
+            const relationshipType = relationshipResource.type
+            let relatedObj = { id: obj[relationshipName][index].id }
+
+            if (data[relationshipType]) {
+              const tempRelatedObj = data[relationshipType].find(d => d.id === obj[relationshipName][index].id)
+
+              if (tempRelatedObj) {
+                relatedObj = tempRelatedObj
+              }
+            }
+
+            return relatedObj
+          })
+        } else {
+          const relationshipType = relationship.type
+
+          if (data[relationshipType]) {
+            const relatedObj = data[relationshipType].find(d => d.id === obj[relationshipName].id)
+
+            if (relatedObj) {
+              obj[relationshipName] = relatedObj
+            }
+          }
+        }
+      })
+    }
+  }
+
+  /**
+   * Remove any circular references from a raw data object
+   * @param  {Object} args
+   * @param  {Object} args.object - the object to check for circular references
+   * @param  {Object} args.processed - a WeakSet of data objects already checked for circular references
+   * @param  {Object} args.visited - a WeakSet of data objects already visited in the object hierarchy
+   */
+  function removeCircularDependencies({ object, processed, visited }) {
+    let queue = []
+
+    processed.add(object)
+
+    Object.keys(object).forEach((key) => {
+      if (Array.isArray(object[key])) {
+        object[key].forEach((item, index) => {
+          if (isObject(item) && item.id) {
+            if (visited.has(item)) {
+              // if the property has already been visited (i.e. the current data object is a descendant of the property object)
+              // replace it with a new object that only contains the id
+              object[key][index] = { id: object[key][index].id }
+            } else if (!processed.has(item)) {
+              // if the property has not been processed,
+              // add it to the queue to remove any circular references it contains
+              queue = queue.concat(object[key])
+            }
+          }
+        })
+      } else if (isObject(object[key]) && object[key].id) {
+        if (visited.has(object[key])) {
+          // if the property has already been visited (i.e. the current data object is a descendant of the property object)
+          // replace it with a new object that only contains the id
+          object[key] = { id: object[key].id }
+        } else if (!processed.has(object[key])) {
+          // if the property has not been processed,
+          // add it to the queue to remove any circular references it contains
+          queue = queue.concat(object[key])
+        }
+      }
+    })
+
+    // add items to visited
+    queue.forEach((item) => {
+      visited.add(item)
+    })
+
+    // process the items
+    queue.forEach((item) => {
+      removeCircularDependencies({ object: item, processed, visited })
+    })
+
+    // remove items from visited
+    queue.forEach((item) => {
+      visited.delete(item)
+    })
+  }
+
   return {
     createInclude,
     getAttributes,
@@ -436,5 +703,12 @@ export default function createTransformalizer(baseOptions = {}) {
     transformData,
     transformRelationshipData,
     transformSource,
+    untransform,
+    untransformResource,
+    getUntransformedDataSchema,
+    getUntransformedId,
+    getUntransformedAttributes,
+    nestRelatedResources,
+    removeCircularDependencies,
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,11 +55,19 @@ export function validateSchema({ name, schema = {} }) {
   if (!isObject(schema.data)) {
     schema.data = {}
   }
+  // validate untransform dataSchema
+  if (schema.data.untransformDataSchema && !isFunction(schema.data.untransformDataSchema)) {
+    throw new Error('Invalid "schema.data.untransformDataSchema" Property')
+  }
   // validate id
   if (!isFunction(schema.data.id)) {
     schema.data.id = function getId({ data }) {
       return data.id.toString()
     }
+  }
+  // validate untransform id
+  if (schema.data.untransformId && !isFunction(schema.data.untransformId)) {
+    throw new Error('Invalid "schema.data.untransformId" Property')
   }
   // validate type
   if (!isFunction(schema.data.type)) {
@@ -75,6 +83,10 @@ export function validateSchema({ name, schema = {} }) {
   if (schema.data.attributes && !isFunction(schema.data.attributes)) {
     throw new Error('Invalid "schema.data.attributes" Property')
   }
+  // validate untransform attributes
+  if (schema.data.untransformAttributes && !isFunction(schema.data.untransformAttributes)) {
+    throw new Error('Invalid "schema.data.untransformAttributes" Property')
+  }
   // validate relationships
   if (schema.data.relationships) {
     if (!isObject(schema.data.relationships)) {
@@ -87,11 +99,183 @@ export function validateSchema({ name, schema = {} }) {
       })
     }
   }
+  // validate top level links
   if (schema.links && !isFunction(schema.links)) {
     throw new Error('Invalid "schema.links" Property')
   }
+  // validate top level meta
   if (schema.meta && !isFunction(schema.meta)) {
     throw new Error('Invalid "schema.meta" Property')
   }
   return schema
+}
+
+/**
+ * Validate a json-api document
+ * @param  {Object} document - an object in json-api format
+ * @private
+ */
+export function validateJsonApiDocument(document) {
+  // validate top level JSON-API document
+  if (!isObject(document)) {
+    throw new Error('JSON-API document must be an object')
+  }
+
+  if (!document.data && !document.errors && !document.meta) {
+    throw new Error('JSON-API document must contain at least one of "data", "errors", or "meta"')
+  }
+
+  if (document.data && document.errors) {
+    throw new Error('JSON-API document must not contain both "data" and "errors"')
+  }
+
+  if (!document.data && document.included) {
+    throw new Error('JSON-API document cannot contain "included" without "data"')
+  }
+
+  if (document.data) {
+    let resources
+
+    if (!Array.isArray(document.data)) {
+      resources = [document.data]
+    } else {
+      resources = document.data
+    }
+
+    // validate primary resources
+    resources.forEach((resource) => {
+      // validate id
+      if (resource.id && !isString(resource.id)) {
+        throw new Error(`Primary data resource id "${resource.id}" must be a string`)
+      }
+
+      // validate type
+      if (!resource.type) {
+        throw new Error(`Primary data resource "${resource.id}" must have a "type" field`)
+      }
+
+      if (!isString(resource.type)) {
+        throw new Error(`Primary data resource type "${resource.type}" must be a string`)
+      }
+
+      // validate attributes
+      if (resource.attributes && !isObject(resource.attributes)) {
+        throw new Error(`Primary data resource "${resource.id}, ${resource.type}" field "attributes" must be an object`)
+      }
+
+      // validate relationships
+      if (resource.relationships) {
+        if (!isObject(resource.relationships)) {
+          throw new Error(`Primary data resource "${resource.id}, ${resource.type}" field "relationships" must be an object`)
+        }
+
+        Object.keys(resource.relationships).forEach((relationshipName) => {
+          const relationship = resource.relationships[relationshipName]
+
+          if (!relationship.data) {
+            throw new Error(`Relationship "${relationshipName}" of primary data resource "${resource.id}, ${resource.type}" must have a "data" field`)
+          }
+
+          let data
+
+          if (!Array.isArray(relationship.data)) {
+            data = [relationship.data]
+          } else {
+            data = relationship.data
+          }
+
+          data.forEach((d) => {
+            if (!d.id) {
+              throw new Error(`Data of relationship "${relationshipName}" of primary data resource "${resource.id}, ${resource.type}" must have an "id" field`)
+            }
+
+            if (!isString(d.id)) {
+              throw new Error(`Data "${d.id}" of relationship "${relationshipName}" of primary data resource "${resource.id}, ${resource.type}" must be a string`)
+            }
+
+            if (!d.type) {
+              throw new Error(`Data "${d.id}" of relationship "${relationshipName}" of primary data resource "${resource.id}, ${resource.type}" must have a "type" field`)
+            }
+
+            if (!isString(d.type)) {
+              throw new Error(`Type "${d.type}" of relationship "${relationshipName}" of primary data resource "${resource.id}, ${resource.type}" must be a string`)
+            }
+          })
+        })
+      }
+    })
+  }
+
+  if (document.included) {
+    if (!Array.isArray(document.included)) {
+      throw new Error('JSON-API document property "included" must be array')
+    }
+
+    // validate included resources
+    document.included.forEach((resource) => {
+      // validate id
+      if (!resource.id) {
+        throw new Error('Included data resource must have an "id" field')
+      }
+
+      if (!isString(resource.id)) {
+        throw new Error(`Included data resource id "${resource.id}" must be a string`)
+      }
+
+      // validate type
+      if (!resource.type) {
+        throw new Error(`Included data resource "${resource.id}" must have a "type" field`)
+      }
+
+      if (!isString(resource.type)) {
+        throw new Error(`Included data resource type "${resource.type}" must be a string`)
+      }
+
+      // validate attributes
+      if (resource.attributes && !isObject(resource.attributes)) {
+        throw new Error(`Included data resource "${resource.id}, ${resource.type}" field "attributes" must be an object`)
+      }
+
+      // validate relationships
+      if (resource.relationships) {
+        if (!isObject(resource.relationships)) {
+          throw new Error(`Included data resource "${resource.id}, ${resource.type}" field "relationships" must be an object`)
+        }
+
+        Object.keys(resource.relationships).forEach((relationshipName) => {
+          const relationship = resource.relationships[relationshipName]
+
+          if (!relationship.data) {
+            throw new Error(`Relationship "${relationshipName}" of included data resource "${resource.id}, ${resource.type}" must have a "data" field`)
+          }
+
+          let data
+
+          if (!Array.isArray(relationship.data)) {
+            data = [relationship.data]
+          } else {
+            data = relationship.data
+          }
+
+          data.forEach((d) => {
+            if (!d.id) {
+              throw new Error(`Data of relationship "${relationshipName}" of included data resource "${resource.id}, ${resource.type}" must have an "id" field`)
+            }
+
+            if (!isString(d.id)) {
+              throw new Error(`Data "${d.id}" of relationship "${relationshipName}" of included data resource "${resource.id}, ${resource.type}" must be a string`)
+            }
+
+            if (!d.type) {
+              throw new Error(`Data "${d.id}" of relationship "${relationshipName}" of included data resource "${resource.id}, ${resource.type}" must have a "type" field`)
+            }
+
+            if (!isString(d.type)) {
+              throw new Error(`Type "${d.type}" of relationship "${relationshipName}" of included data resource "${resource.id}, ${resource.type}" must be a string`)
+            }
+          })
+        })
+      }
+    })
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "coverage": "./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover ./node_modules/.bin/_mocha test/tests/*.test.js",
     "postversion": "npm run build",
     "release": "npm run build && standard-version",
-    "test": "mocha --compilers js:babel-register test/tests/**/*.test.js"
+    "test": "mocha --compilers js:babel-register test/tests/**/*.test.js",
+    "lint": "./node_modules/.bin/eslint ./lib ./test"
   },
   "contributors": [
     {
@@ -66,6 +67,7 @@
     "standard-version": "^4.0.0"
   },
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "source-map-support": "^0.4.11"
   }
 }

--- a/test/tests/untransform.test.js
+++ b/test/tests/untransform.test.js
@@ -1,0 +1,301 @@
+import { expect } from 'chai'
+import _ from 'lodash'
+import { describe, it } from 'mocha'
+
+import transformalizer from '../transformalizers/untransform'
+
+const tags = [
+  { id: 501, name: 'kids', description: 'Intended for kids' },
+  { id: 502, name: 'fantasy', description: 'Fantasy' },
+  { id: 503, name: 'magic', description: 'Contains magic/magical effects' },
+  { id: 504, name: 'school', description: 'Set in an educational environment' },
+]
+
+const authors = [
+  { id: 401, firstName: 'J. R. R.', lastName: 'Tolkien' },
+  { id: 402, firstName: 'C.S.', lastName: 'Lewis' },
+  { id: 403, firstName: 'J. K.', lastName: 'Rowling' },
+  { id: 404, firstName: 'Ernest', lastName: 'Hemingway' },
+  { id: 405, firstName: 'John', lastName: 'Steinbeck' },
+  { id: 406, firstName: 'Mark', lastName: 'Twain' },
+]
+
+const reviews = [
+  { id: 301, title: 'Immersive!', content: 'An epic of epic proprotions', rating: 5, author: authors[3] },
+  { id: 302, title: 'Very long and boring', content: 'Did you really need to describe every inch of the landscape?', rating: 2, author: authors[5] },
+  { id: 303, title: 'Good, but...', content: 'Not enough epic poems', rating: 3, author: authors[4] },
+]
+
+const publishers = [
+  { id: 201, name: 'Allen & Unwin' },
+  { id: 202, name: 'HarperCollins' },
+  { id: 203, name: 'Bloomsbury Publishing' },
+]
+
+const books = [
+  { id: 101, title: 'The Fellowship of the Ring', copyright: 1954, author: authors[0], reviews: _.slice(reviews, 0, 2), publisher: publishers[0], tags: [tags[1], tags[2]] },
+  { id: 102, title: 'The Two Towers', copyright: 1954, author: authors[0], reviews: [], publisher: publishers[0], tags: [tags[1], tags[2]] },
+  { id: 103, title: 'The Return of the King', copyright: 1955, author: authors[0], reviews: [], publisher: publishers[0], tags: [tags[1], tags[2]] },
+  { id: 104, title: 'The Magician\'s Nephew', copyright: 1955, author: authors[1], reviews: [{ id: 4 }, { id: 5 }], publisher: publishers[1], tags: [tags[0], tags[1], tags[3]] },
+  { id: 105, title: 'The Lion, the Witch and the Wardrobe', copyright: 1950, author: authors[1], reviews: [], publisher: publishers[1], tags: [tags[0], tags[1], tags[3]] },
+  { id: 106, title: 'The Horse and His Boy', copyright: 1954, author: authors[1], reviews: [], publisher: publishers[1], tags: [tags[0], tags[1], tags[3]] },
+  { id: 107, title: 'Prince Caspian: The Return to Narnia', copyright: 1951, author: authors[1], reviews: [], publisher: publishers[1], tags: [tags[0], tags[1], tags[3]] },
+  { id: 108, title: 'The Voyage of the Dawn Treader', copyright: 1952, author: authors[1], reviews: [], publisher: publishers[1], tags: [tags[0], tags[1], tags[3]] },
+  { id: 109, title: 'The Silver Chair', copyright: 1953, author: authors[1], reviews: [], publisher: publishers[1], tags: [tags[0], tags[1], tags[3]] },
+  { id: 110, title: 'The Last Battle', copyright: 1956, author: authors[1], reviews: [], publisher: publishers[1], tags: [tags[0], tags[1], tags[3]] },
+  { id: 111, title: 'Harry Potter and the Philosopher\'s Stone', copyright: 1997, author: authors[2], reviews: [reviews[2]], publisher: publishers[2], tags },
+  { id: 112, title: 'Harry Potter and the Chamber of Secrets', copyright: 1998, author: authors[2], reviews: [], publisher: publishers[2], tags },
+  { id: 113, title: 'Harry Potter and the Prisoner of Azkaban', copyright: 1999, author: authors[2], reviews: [], publisher: publishers[2], tags },
+  { id: 114, title: 'Harry Potter and the Goblet of Fire', copyright: 2000, author: authors[2], reviews: [], publisher: publishers[2], tags },
+  { id: 115, title: 'Harry Potter and the Order of the Phoenix', copyright: 2003, author: authors[2], reviews: [], publisher: publishers[2], tags },
+  { id: 116, title: 'Harry Potter and the Half-Blood Prince', copyright: 2005, author: authors[2], reviews: [], publisher: publishers[2], tags },
+  { id: 117, title: 'Harry Potter and the Deathly Hallows', copyright: 2007, author: authors[2], reviews: [{ id: 6 }], publisher: publishers[2], tags },
+]
+
+authors[0].books = _.slice(books, 0, 3)
+authors[1].books = _.slice(books, 3, 10)
+authors[2].books = _.slice(books, 10, 17)
+authors[3].reviews = [reviews[0]]
+authors[4].reviews = [reviews[2]]
+authors[5].reviews = [reviews[1]]
+
+const series = [
+  { id: 1, title: 'Lord of the Rings', books: _.slice(books, 0, 3) },
+  { id: 2, title: 'The Chronicles of Narnia', books: _.slice(books, 3, 10) },
+  { id: 3, title: 'Harry Potter', books: _.slice(books, 10, 17) },
+]
+
+describe('untransform', function () {
+  it('single primary data only', function () {
+    const payload = transformalizer.transform({ name: 'series', source: series[0], options: {} })
+    const data = transformalizer.untransform({ document: payload })
+
+    expect(data).to.have.all.keys('series')
+
+    expect(data.series).to.be.an('array').with.lengthOf(1)
+    expect(data.series[0]).to.have.property('id', series[0].id)
+    expect(data.series[0]).to.have.property('title', series[0].title)
+    expect(data.series[0]).to.have.property('books')
+    expect(data.series[0].books).to.be.an('array').with.lengthOf(series[0].books.length)
+    expect(data.series[0].books).to.have.deep.members(series[0].books.map(book => ({ id: book.id })))
+  })
+
+  it('single primary data and included data', function () {
+    const payload = transformalizer.transform({ name: 'series', source: series[2] })
+    const data = transformalizer.untransform({ document: payload, options: { untransformIncluded: true } })
+
+    expect(data).to.have.all.keys('series', 'book', 'tag', 'author', 'review', 'publisher')
+
+    expect(data.series).to.be.an('array').with.lengthOf(1)
+    expect(data.series[0]).to.have.property('id', series[2].id)
+    expect(data.series[0]).to.have.property('title', series[2].title)
+    expect(data.series[0]).to.have.property('books')
+    expect(data.series[0].books).to.be.an('array').with.lengthOf(series[2].books.length)
+    expect(data.series[0].books).to.have.deep.members(series[2].books.map(book => ({ id: book.id })))
+
+    expect(data.book).to.be.an('array').with.lengthOf(7)
+    expect(data.book).to.have.deep.members(series[2].books.map(book => ({
+      id: book.id,
+      title: book.title,
+      copyright: book.copyright,
+      author: { id: book.author.id },
+      reviews: book.reviews.map(review => ({ id: review.id })),
+      publisher: { id: book.publisher.id },
+      tags: book.tags.map(tag => ({ id: tag.id })),
+    })))
+
+    expect(data.tag).to.be.an('array').with.lengthOf(4)
+    expect(data.tag).to.have.deep.members(tags)
+
+    expect(data.author).to.be.an('array').with.lengthOf(2)
+    expect(data.author).to.have.deep.members([authors[2], authors[4]].map((author) => {
+      const newAuthor = {
+        id: author.id,
+        firstName: author.firstName,
+        lastName: author.lastName,
+      }
+
+      if (author.books) {
+        newAuthor.books = author.books.map(book => ({ id: book.id }))
+      }
+
+      if (author.reviews) {
+        newAuthor.reviews = author.reviews.map(review => ({ id: review.id }))
+      }
+
+      return newAuthor
+    }))
+
+    expect(data.review).to.be.an('array').with.lengthOf(2)
+    expect(data.review).to.have.deep.members(_.flatMap(series[2].books, 'reviews').map((review) => {
+      const newReview = { id: review.id }
+
+      if (review.title) {
+        newReview.title = review.title
+      }
+
+      if (review.content) {
+        newReview.content = review.content
+      }
+
+      if (review.rating) {
+        newReview.rating = review.rating
+      }
+
+      if (review.author) {
+        newReview.author = { id: review.author.id }
+      }
+
+      return newReview
+    }))
+
+    expect(data.publisher).to.be.an('array').with.lengthOf(1)
+    expect(data.publisher[0]).to.deep.equal(publishers[2])
+  })
+
+  it('single primary data and nest included data', function () {
+    const payload = transformalizer.transform({ name: 'series', source: series[2] })
+    const data = transformalizer.untransform({ document: payload, options: { untransformIncluded: true, nestIncluded: true } })
+
+    expect(data).to.have.all.keys('series', 'book', 'tag', 'author', 'review', 'publisher')
+
+    expect(data.series).to.be.an('array').with.lengthOf(1)
+    expect(data.book).to.be.an('array').with.lengthOf(7)
+    expect(data.tag).to.be.an('array').with.lengthOf(4)
+    expect(data.author).to.be.an('array').with.lengthOf(2)
+    expect(data.review).to.be.an('array').with.lengthOf(2)
+    expect(data.publisher).to.be.an('array').with.lengthOf(1)
+
+    expect(data.series[0]).to.have.property('id', series[2].id)
+    expect(data.series[0]).to.have.property('title', series[2].title)
+    expect(data.series[0]).to.have.property('books')
+    expect(data.series[0].books).to.be.an('array').with.lengthOf(series[2].books.length)
+
+    data.series[0].books.forEach((book) => {
+      const expectedBook = series[2].books.find(b => book.id === b.id)
+
+      expect(expectedBook).to.not.equal(undefined)
+      expect(book).to.have.property('title', expectedBook.title)
+      expect(book).to.have.property('copyright', expectedBook.copyright)
+
+      expect(book).to.have.property('author')
+      expect(book.author).to.have.property('id', expectedBook.author.id)
+      expect(book.author).to.have.property('firstName', expectedBook.author.firstName)
+      expect(book.author).to.have.property('lastName', expectedBook.author.lastName)
+      expect(book.author.books).to.be.an('array').with.lengthOf(expectedBook.author.books.length)
+      book.author.books.forEach((nestedBook) => {
+        const expectedNestedBook = expectedBook.author.books.find(b => nestedBook.id === b.id)
+
+        expect(expectedNestedBook).to.not.equal(undefined)
+        expect(nestedBook).to.have.property('title', expectedNestedBook.title)
+        expect(nestedBook).to.have.property('copyright', expectedNestedBook.copyright)
+      })
+
+      if (book.author.reviews) {
+        expect(book.author.reviews).to.be.an('array').with.lengthOf(expectedBook.author.reviews.length)
+        expect(book.author.reviews).to.have.deep.members(expectedBook.author.reviews.map(review => ({ id: review.id })))
+      }
+
+      expect(book.reviews).to.be.an('array').with.lengthOf(expectedBook.reviews.length)
+      book.reviews.forEach((review) => {
+        const expectedReview = expectedBook.reviews.find(r => review.id === r.id)
+
+        expect(expectedReview).to.not.equal(undefined)
+        expect(review.title).to.equal(expectedReview.title)
+        expect(review.content).to.equal(expectedReview.content)
+        expect(review.rating).to.equal(expectedReview.rating)
+
+        if (expectedReview.author) {
+          expect(review).to.have.property('author')
+          expect(review.author).to.have.property('id', expectedReview.author.id)
+          expect(review.author).to.have.property('firstName', expectedReview.author.firstName)
+          expect(review.author).to.have.property('lastName', expectedReview.author.lastName)
+        }
+      })
+
+      expect(book).to.have.property('publisher')
+      expect(book.publisher).to.have.property('id', expectedBook.publisher.id)
+      expect(book.publisher).to.have.property('name', expectedBook.publisher.name)
+
+      expect(book.tags).to.be.an('array').with.lengthOf(expectedBook.tags.length)
+      expect(book.tags).to.have.deep.members(expectedBook.tags)
+    })
+  })
+
+  it('single primary data, nest included data, and remove circular references', function () {
+    const payload = transformalizer.transform({ name: 'series', source: series[2] })
+    const data = transformalizer.untransform({ document: payload, options: { untransformIncluded: true, nestIncluded: true, removeCircularDependencies: true } })
+    const expectedSeries = _.cloneDeep(series[2])
+
+    expectedSeries.books.forEach((book) => {
+      book.reviews.forEach((review) => {
+        if (review.author) {
+          if (review.author.books) {
+            review.author.books = review.author.books.map(b => ({ id: b.id }))
+          }
+
+          if (review.author.reviews) {
+            review.author.reviews = review.author.reviews.map(r => ({ id: r.id }))
+          }
+        }
+      })
+
+      if (book.author.reviews) {
+        book.author.reviews = book.author.reviews.map(review => ({ id: review.id }))
+      }
+
+      if (book.author.books) {
+        book.author.books = book.author.books.map(nestedBook => ({ id: nestedBook.id }))
+      }
+    })
+
+    expect(data).to.have.all.keys('series', 'book', 'tag', 'author', 'review', 'publisher')
+
+    expect(data.series).to.be.an('array').with.lengthOf(1)
+    expect(data.book).to.be.an('array').with.lengthOf(7)
+    expect(data.tag).to.be.an('array').with.lengthOf(4)
+    expect(data.author).to.be.an('array').with.lengthOf(2)
+    expect(data.review).to.be.an('array').with.lengthOf(2)
+    expect(data.publisher).to.be.an('array').with.lengthOf(1)
+
+    expect(data.series[0]).to.be.deep.equal(expectedSeries)
+  })
+
+  it('multiple primary data, nest included data, and remove circular references', function () {
+    const payload = transformalizer.transform({ name: 'series', source: series })
+    const data = transformalizer.untransform({ document: payload, options: { untransformIncluded: true, nestIncluded: true, removeCircularDependencies: true } })
+
+    const expectedSeries = _.cloneDeep(series)
+    expectedSeries.forEach((s) => {
+      s.books.forEach((book) => {
+        book.reviews.forEach((review) => {
+          if (review.author) {
+            if (review.author.reviews) {
+              review.author.reviews = review.author.reviews.map(nestedReview => ({ id: nestedReview.id }))
+            }
+          }
+        })
+
+        if (book.author.reviews) {
+          book.author.reviews = book.author.reviews.map(review => ({ id: review.id }))
+        }
+
+        if (book.author.books) {
+          book.author.books = book.author.books.map(nestedBook => ({ id: nestedBook.id }))
+        }
+      })
+    })
+
+    expect(data).to.have.all.keys('series', 'book', 'tag', 'author', 'review', 'publisher')
+
+    expect(data.series).to.be.an('array').with.lengthOf(3)
+    expect(data.book).to.be.an('array').with.lengthOf(17)
+    expect(data.tag).to.be.an('array').with.lengthOf(4)
+    expect(data.author).to.be.an('array').with.lengthOf(6)
+    expect(data.review).to.be.an('array').with.lengthOf(6)
+    expect(data.publisher).to.be.an('array').with.lengthOf(3)
+
+    expect(data.series).to.be.deep.equal(expectedSeries)
+  })
+})
+

--- a/test/tests/utils.test.js
+++ b/test/tests/utils.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
-import { TransformError, validateSchema } from '../../lib/utils'
+import { TransformError, validateSchema, validateJsonApiDocument } from '../../lib/utils'
 
 describe('TransformError', function () {
   it('should be instanceof Error', function () {
@@ -23,41 +23,213 @@ describe('validateSchema', function () {
 
   it('should fail if schema is not an object', function () {
     const schema = 'foo'
-    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw(Error)
+    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw('Invalid "schema" Property')
+  })
+
+  it('should fail if schema.data.untransformDataSchema exists and is not a function', function () {
+    const schema = { data: { untransformDataSchema: 'foo' } }
+    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw('Invalid "schema.data.untransformDataSchema" Property')
+  })
+
+  it('should fail if schema.data.untransformId exists and is not a function', function () {
+    const schema = { data: { untransformId: 'foo' } }
+    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw('Invalid "schema.data.untransformId" Property')
   })
 
   it('should fail if schema.data.links exists and is not a function', function () {
     const schema = { data: { links: 'foo' } }
-    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw(Error)
+    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw('Invalid "schema.data.links" Property')
   })
 
   it('should fail if schema.data.meta exists and is not a function', function () {
     const schema = { data: { meta: 'foo' } }
-    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw(Error)
+    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw('Invalid "schema.data.meta" Property')
   })
 
   it('should fail if schema.data.attributes exists and is not a function', function () {
     const schema = { data: { attributes: 'foo' } }
-    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw(Error)
+    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw('Invalid "schema.data.attributes" Property')
+  })
+
+  it('should fail if schema.data.untransformAttributes exists and is not a function', function () {
+    const schema = { data: { untransformAttributes: 'foo' } }
+    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw('Invalid "schema.data.untransformAttributes" Property')
   })
 
   it('should fail if schema.data.relationships exists and is not an object', function () {
     const schema = { data: { relationships() {} } }
-    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw(Error)
+    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw('Invalid "schema.data.relationships" Property')
   })
 
   it('should fail if a relationship key exists and its value is not a function', function () {
     const schema = { data: { relationships: { foo: 'bar' } } }
-    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw(Error)
+    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw('Invalid Schema: Relationship "foo" should be a function')
   })
 
   it('should fail if schema.links exists and is not a function', function () {
     const schema = { links: 'foo' }
-    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw(Error)
+    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw('Invalid "schema.links" Property')
   })
 
   it('should fail if schema.meta exists and is not a function', function () {
     const schema = { meta: 'foo' }
-    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw(Error)
+    expect(validateSchema.bind(null, { name: 'test', schema })).to.throw('Invalid "schema.meta" Property')
+  })
+})
+
+describe('validateJsonApiDocument', function () {
+  const documentTemplate = {
+    data: {
+      id: '1',
+      type: 'article',
+      attributes: {
+        title: 'JSON-API validation requirements',
+        content: 'JSON-API validation requires ...',
+      },
+      relationships: {
+        author: {
+          data: {
+            id: '1',
+            type: 'author',
+          },
+        },
+      },
+    },
+    included: [
+      {
+        id: '1',
+        type: 'author',
+        attributes: {
+          firstName: 'John',
+          lastName: 'Doe',
+        },
+        relationships: {
+          contactInfo: {
+            data: [
+              {
+                id: '1',
+                type: 'contactInformation',
+              },
+            ],
+          },
+        },
+      },
+      {
+        id: '1',
+        type: 'contactInformation',
+        attributes: {
+          phone: '555-123-4567',
+          email: 'john.doe@localhost.com',
+        },
+      },
+    ],
+    links: {
+      self: 'http://localhost:80/',
+    },
+    meta: {
+      license: 'MIT',
+    },
+  }
+
+  it('should succeed if the JSON-API document is valid', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    expect(validateJsonApiDocument.bind(null, document)).to.not.throw()
+  })
+
+  it('should fail if the JSON-API document is not an object', function () {
+    const document = JSON.stringify(documentTemplate)
+    expect(validateJsonApiDocument.bind(null, document)).to.throw('JSON-API document must be an object')
+  })
+
+  it('should fail if the JSON-API document is missing the primary top level fields', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    delete document.data
+    delete document.meta
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw('JSON-API document must contain at least one of "data", "errors", or "meta"')
+  })
+
+  it('should fail if the JSON-API document contains both "data" and "errors" fields', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    document.errors = [{ detail: 'Article 1 does not exist' }]
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw('JSON-API document must not contain both "data" and "errors"')
+  })
+
+  it('should fail if the JSON-API document contains "included" field but not "data" field', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    delete document.data
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw('JSON-API document cannot contain "included" without "data"')
+  })
+
+  it('should fail if the JSON-API document primary data resource id is not a string', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    document.data.id = 1
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw(`Primary data resource id "${document.data.id}" must be a string`)
+  })
+
+  it('should fail if the JSON-API document primary data resource type is missing', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    delete document.data.type
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw(`Primary data resource "${document.data.id}" must have a "type" field`)
+  })
+
+  it('should fail if the JSON-API document primary data resource type is not a string', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    document.data.type = 1
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw(`Primary data resource type "${document.data.type}" must be a string`)
+  })
+
+  it('should fail if the JSON-API document primary data resource attributes is not an object', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    document.data.attributes = "{title: 'JSON-API validation requirements'}"
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw(`Primary data resource "${document.data.id}, ${document.data.type}" field "attributes" must be an object`)
+  })
+
+  it('should fail if the JSON-API document primary data resource relationships is not an object', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    document.data.relationships = '{author: {data: {id: 1, type: author}}}'
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw(`Primary data resource "${document.data.id}, ${document.data.type}" field "relationships" must be an object`)
+  })
+
+  it('should fail if the JSON-API document primary data resource relationship data is missing', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    delete document.data.relationships.author.data
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw(`Relationship "author" of primary data resource "${document.data.id}, ${document.data.type}" must have a "data" field`)
+  })
+
+  it('should fail if the JSON-API document primary data resource relationship id is missing', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    delete document.data.relationships.author.data.id
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw(`Data of relationship "author" of primary data resource "${document.data.id}, ${document.data.type}" must have an "id" field`)
+  })
+
+  it('should fail if the JSON-API document primary data resource relationship id is not a string', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    document.data.relationships.author.data.id = 1
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw(`Data "${document.data.relationships.author.data.id}" of relationship "author" of primary data resource "${document.data.id}, ${document.data.type}" must be a string`)
+  })
+
+  it('should fail if the JSON-API document primary data resource relationship type is missing', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    delete document.data.relationships.author.data.type
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw(`Data "${document.data.relationships.author.data.id}" of relationship "author" of primary data resource "${document.data.id}, ${document.data.type}" must have a "type" field`)
+  })
+
+  it('should fail if the JSON-API document primary data resource relationship type is not a string', function () {
+    const document = JSON.parse(JSON.stringify(documentTemplate))
+    document.data.relationships.author.data.type = 1
+
+    expect(validateJsonApiDocument.bind(null, document)).to.throw(`Type "${document.data.relationships.author.data.type}" of relationship "author" of primary data resource "${document.data.id}, ${document.data.type}" must be a string`)
   })
 })

--- a/test/transformalizers/untransform/author.js
+++ b/test/transformalizers/untransform/author.js
@@ -1,0 +1,50 @@
+import R from 'ramda'
+
+export default {
+  name: 'author',
+  schema: {
+    data: {
+      type: R.always('author'),
+      id: R.compose(R.toString, R.path(['data', 'id'])),
+      untransformId: R.compose(Number, R.path(['id'])),
+      attributes({ data }) {
+        const attributes = R.pick(['firstName', 'lastName'], data)
+        return R.isEmpty(attributes) ? undefined : attributes
+      },
+      untransformAttributes: R.path(['attributes']),
+      relationships: {
+        books({ data }) {
+          const books = R.prop('books', data)
+          if (!books) {
+            return undefined
+          }
+          return {
+            data: books.map(book => ({
+              name: 'book',
+              data: book,
+              included: false,
+            })),
+          }
+        },
+        reviews({ data }) {
+          const reviews = R.prop('reviews', data)
+          if (!reviews) {
+            return undefined
+          }
+          return {
+            data: reviews.map(review => ({
+              name: 'review',
+              data: review,
+              included: false,
+            })),
+          }
+        },
+      },
+      links({ options, id }) {
+        return {
+          self: `${options.url}/authors/${id}`,
+        }
+      },
+    },
+  },
+}

--- a/test/transformalizers/untransform/book.js
+++ b/test/transformalizers/untransform/book.js
@@ -1,0 +1,76 @@
+import R from 'ramda'
+
+export default {
+  name: 'book',
+  schema: {
+    data: {
+      type: R.always('book'),
+      id: R.compose(R.toString, R.path(['data', 'id'])),
+      untransformId: R.compose(Number, R.path(['id'])),
+      attributes({ data }) {
+        const attributes = R.pick(['title', 'copyright'], data)
+        return R.isEmpty(attributes) ? undefined : attributes
+      },
+      untransformAttributes: R.path(['attributes']),
+      relationships: {
+        author({ data }) {
+          const author = R.prop('author', data)
+          if (!author) {
+            return undefined
+          }
+          return {
+            data: {
+              name: 'author',
+              data: author,
+              included: true,
+            },
+          }
+        },
+        reviews({ data }) {
+          const reviews = R.prop('reviews', data)
+          if (!reviews) {
+            return undefined
+          }
+          return {
+            data: reviews.map(review => ({
+              name: 'review',
+              data: review,
+              included: true,
+            })),
+          }
+        },
+        publisher({ data }) {
+          const publisher = R.prop('publisher', data)
+          if (!publisher) {
+            return undefined
+          }
+          return {
+            data: {
+              name: 'publisher',
+              data: publisher,
+              included: true,
+            },
+          }
+        },
+        tags({ data }) {
+          const tags = R.prop('tags', data)
+          if (!tags) {
+            return undefined
+          }
+          return {
+            data: tags.map(tag => ({
+              name: 'tag',
+              data: tag,
+              included: true,
+            })),
+          }
+        },
+      },
+      links({ options, id }) {
+        return {
+          self: `${options.url}/books/${id}`,
+        }
+      },
+    },
+  },
+}

--- a/test/transformalizers/untransform/index.js
+++ b/test/transformalizers/untransform/index.js
@@ -1,0 +1,19 @@
+import createTransformalizer from '../../../lib/transformalizer'
+import author from './author'
+import book from './book'
+import publisher from './publisher'
+import review from './review'
+import series from './series'
+import tag from './tag'
+
+const options = { url: 'https://api.example.com' }
+
+const transformalizer = createTransformalizer(options)
+transformalizer.register(author)
+transformalizer.register(book)
+transformalizer.register(publisher)
+transformalizer.register(review)
+transformalizer.register(series)
+transformalizer.register(tag)
+
+export default transformalizer

--- a/test/transformalizers/untransform/publisher.js
+++ b/test/transformalizers/untransform/publisher.js
@@ -1,0 +1,22 @@
+import R from 'ramda'
+
+export default {
+  name: 'publisher',
+  schema: {
+    data: {
+      type: R.always('publisher'),
+      id: R.compose(R.toString, R.path(['data', 'id'])),
+      untransformId: R.compose(Number, R.path(['id'])),
+      attributes({ data }) {
+        const attributes = R.pick(['name'], data)
+        return R.isEmpty(attributes) ? undefined : attributes
+      },
+      untransformAttributes: R.path(['attributes']),
+      links({ options, id }) {
+        return {
+          self: `${options.url}/publishers/${id}`,
+        }
+      },
+    },
+  },
+}

--- a/test/transformalizers/untransform/review.js
+++ b/test/transformalizers/untransform/review.js
@@ -1,0 +1,37 @@
+import R from 'ramda'
+
+export default {
+  name: 'review',
+  schema: {
+    data: {
+      type: R.always('review'),
+      id: R.compose(R.toString, R.path(['data', 'id'])),
+      untransformId: R.compose(Number, R.path(['id'])),
+      attributes({ data }) {
+        const attributes = R.pick(['title', 'content', 'rating'], data)
+        return R.isEmpty(attributes) ? undefined : attributes
+      },
+      untransformAttributes: R.path(['attributes']),
+      relationships: {
+        author({ data }) {
+          const author = R.prop('author', data)
+          if (!author) {
+            return undefined
+          }
+          return {
+            data: {
+              name: 'author',
+              data: author,
+              included: true,
+            },
+          }
+        },
+      },
+      links({ options, id }) {
+        return {
+          self: `${options.url}/reviews/${id}`,
+        }
+      },
+    },
+  },
+}

--- a/test/transformalizers/untransform/series.js
+++ b/test/transformalizers/untransform/series.js
@@ -1,0 +1,37 @@
+import R from 'ramda'
+
+export default {
+  name: 'series',
+  schema: {
+    data: {
+      type: R.always('series'),
+      id: R.compose(R.toString, R.path(['data', 'id'])),
+      untransformId: R.compose(Number, R.path(['id'])),
+      attributes({ data }) {
+        const attributes = R.pick(['title'], data)
+        return R.isEmpty(attributes) ? undefined : attributes
+      },
+      untransformAttributes: R.path(['attributes']),
+      relationships: {
+        books({ data }) {
+          const books = R.prop('books', data)
+          if (!books) {
+            return undefined
+          }
+          return {
+            data: books.map(book => ({
+              name: 'book',
+              data: book,
+              included: true,
+            })),
+          }
+        },
+      },
+      links({ options, id }) {
+        return {
+          self: `${options.url}/series/${id}`,
+        }
+      },
+    },
+  },
+}

--- a/test/transformalizers/untransform/tag.js
+++ b/test/transformalizers/untransform/tag.js
@@ -1,0 +1,22 @@
+import R from 'ramda'
+
+export default {
+  name: 'tag',
+  schema: {
+    data: {
+      type: R.always('tag'),
+      id: R.compose(R.toString, R.path(['data', 'id'])),
+      untransformId: R.compose(Number, R.path(['id'])),
+      attributes({ data }) {
+        const attributes = R.pick(['name', 'description'], data)
+        return R.isEmpty(attributes) ? undefined : attributes
+      },
+      untransformAttributes: R.path(['attributes']),
+      links({ options, id }) {
+        return {
+          self: `${options.url}/tags/${id}`,
+        }
+      },
+    },
+  },
+}


### PR DESCRIPTION
This contains new functionality to "untransform" a json-api document back to plain old javascript objects.  It can convert primary resources and included resources.  It also provides the ability to recreate the full object hierarchy and remove circular references if there are any.

I chose the term "untransform" to provide a counter point to the "transform" functionality.  I also tried to replicate the original coding style and methodology as much as possible.