### PR TITLE
fix(transform): allow resource linkage to be null

### DIFF
--- a/lib/transformalizer.js
+++ b/lib/transformalizer.js
@@ -271,7 +271,7 @@ export default function createTransformalizer(baseOptions = {}) {
       return undefined
     }
     const { meta, links, data } = result
-    const invalidData = !data || typeof data !== 'object'
+    const invalidData = (typeof data === 'undefined' || typeof data !== 'object')
     if (!links && !meta && invalidData) {
       return undefined
     }
@@ -284,6 +284,8 @@ export default function createTransformalizer(baseOptions = {}) {
           options: args.options,
           include,
         }))
+      } else if (data === null) {
+        relationship.data = null
       } else {
         relationship.data = transformRelationshipData({
           item: data,

--- a/test/tests/misc.test.js
+++ b/test/tests/misc.test.js
@@ -22,5 +22,13 @@ describe('miscellaneous', function () {
     const uniqueIncluded = _.uniqBy(payload.included, included => `${included.type}:${included.id}`)
 
     expect(uniqueIncluded).to.be.an('array').with.lengthOf(payload.included.length)
+  }),
+
+  it('the data attribute can be null for empty to-one relations', function () {
+    const book = { id: 1, title: 'Beowulf', author: null }
+
+    const payload = transformalizer.transform({ name: 'book', source: book })
+
+    expect(payload.data.relationships.author.data).to.be.a('null')
   })
 })

--- a/test/transformalizers/misc/book.js
+++ b/test/transformalizers/misc/book.js
@@ -15,8 +15,11 @@ export default {
       relationships: {
         author({ data }) {
           const author = R.prop('author', data)
-          if (!author) {
+          if (typeof author === 'undefined') {
             return undefined
+          }
+          if (!author) {
+            return { data: null }
           }
           return {
             data: {


### PR DESCRIPTION
According to [the spec](http://jsonapi.org/format/#document-resource-object-linkage) resource linkage objects may be null for empty to-one relationships. This PR allows nulls to pass through the transformation process.