### PR TITLE
Break explicit dependency on babel-polyfill

### DIFF
--- a/lib/transformalizer.js
+++ b/lib/transformalizer.js
@@ -1,5 +1,3 @@
-import 'babel-polyfill'
-
 import {
   isFunction,
   isObject,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coverage": "./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover ./node_modules/.bin/_mocha test/tests/*.test.js",
     "postversion": "npm run build",
     "release": "npm run build && standard-version",
-    "test": "mocha --compilers js:babel-register test/tests/**/*.test.js",
+    "test": "mocha --require babel-polyfill --compilers js:babel-register test/tests/**/*.test.js",
     "lint": "./node_modules/.bin/eslint ./lib ./test"
   },
   "contributors": [
@@ -64,10 +64,9 @@
     "qs": "^6.3.0",
     "ramda": "^0.23.0",
     "sinon": "^1.17.7",
-    "standard-version": "^4.0.0"
-  },
-  "dependencies": {
+    "standard-version": "^4.0.0",
     "babel-polyfill": "^6.26.0",
     "source-map-support": "^0.4.11"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
babel-polyfill can only be loaded once in a project and according to the documentation is aimed at programs and not so much libs. I added it as a dev-dependency and made sure mocha will import it before running the tests so development works.

Depending on how transformalizer is used the host program might need to load babel-polyfill or transformalizer can include core-js and use those polyfills.