### PR TITLE
fix: prevents duplicate schema definitions

### DIFF
--- a/lib/transformalizer.js
+++ b/lib/transformalizer.js
@@ -27,6 +27,9 @@ export default function createTransformalizer(baseOptions = {}) {
     if (!isString(name)) {
       throw new Error('Invalid "name" Property (non string)')
     }
+    if (registry[name]) {
+      throw new Error(`Duplicate "name" in registry: ${name}`)
+    }
     registry[name] = {
       schema: validateSchema({ name, schema }),
       options: schemaOptions,

--- a/test/tests/errors.test.js
+++ b/test/tests/errors.test.js
@@ -9,6 +9,12 @@ describe('errors and coverage', function () {
       const transformalizer = createTransformalizer()
       expect(transformalizer.register.bind(null, {})).to.throw(Error)
     })
+
+    it('should throw if the name is duplicated', function () {
+      const transformalizer = createTransformalizer()
+      transformalizer.register({ name: 'duplicate-schema' })
+      expect(transformalizer.register.bind(null, { name: 'duplicate-schema' })).to.throw(Error)
+    })
   })
 
   describe('#transform', function () {
@@ -101,8 +107,8 @@ describe('errors and coverage', function () {
           },
         },
       }
-      transformalizer.register({ name: 'no-relationships', schema })
-      expect(transformalizer.transform({ name: 'no-relationships', source: { id: 1 } }))
+      transformalizer.register({ name: 'no-relationships-2', schema })
+      expect(transformalizer.transform({ name: 'no-relationships-2', source: { id: 1 } }))
       .to.not.have.deep.property('data.relationships')
     })
 


### PR DESCRIPTION
When a schema is registered multiple times, the most recent registration "wins". This can be confusing when you add a schema that you didn't realize you already had. I personally ran into this when using the library. It would be great if the developer received an error when this happened.